### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -28,9 +28,18 @@ namespace NuGet.Packaging
             return entry;
         }
 
-        public static IEnumerable<string> GetFiles(this ZipArchive zipArchive)
+        public static IEnumerable<string> GetFiles(this ZipArchive zipArchive, string destinationDirectory)
         {
-            return zipArchive.Entries.Select(e => UnescapePath(e.FullName));
+            string fullDestDirPath = Path.GetFullPath(destinationDirectory + Path.DirectorySeparatorChar);
+            return zipArchive.Entries.Select(e =>
+            {
+                string fullPath = Path.GetFullPath(Path.Combine(destinationDirectory, UnescapePath(e.FullName)));
+                if (!fullPath.StartsWith(fullDestDirPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException($"Entry is outside the target directory: {e.FullName}");
+                }
+                return fullPath;
+            });
         }
 
         private static string UnescapePath(string path)

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -93,15 +93,15 @@ namespace NuGet.Packaging
 
         private FileInfo GetFile(string path)
         {
-            var file = new FileInfo(Path.Combine(_root.FullName, path));
+            var fullPath = Path.GetFullPath(Path.Combine(_root.FullName, path));
 
-            if (!file.FullName.StartsWith(_root.FullName, StringComparison.OrdinalIgnoreCase))
+            if (!fullPath.StartsWith(_root.FullName + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
             {
                 // the given path does not appear under the folder root
-                throw new FileNotFoundException(path);
+                throw new FileNotFoundException($"Path is outside the root directory: {path}");
             }
 
-            return file;
+            return new FileInfo(fullPath);
         }
 
         public override IEnumerable<string> GetFiles()


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/NuGet.Client/security/code-scanning/1](https://github.com/codeallthethingsbreak/NuGet.Client/security/code-scanning/1)

To fix the issue, we need to sanitize and validate paths extracted from the zip archive to prevent directory traversal attacks. Specifically:
1. Use `Path.GetFullPath` to resolve the full path of the file to handle any directory traversal elements.
2. Use `Path.GetFullPath` on the destination directory to get its fully resolved path.
3. Ensure that the resolved file path starts with the resolved destination directory path. If not, throw an exception.

The changes will be applied to the `ZipArchiveExtensions.GetFiles` method to sanitize the paths before returning them. Additionally, the `PackageFolderReader.GetFile` method will be updated to ensure paths are validated after combining.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
